### PR TITLE
[skip ci] Do not fail fast in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         version:
           - "1.3"


### PR DESCRIPTION
Currently, if a job fails, all other jobs are immediately cancelled.  By setting
`fail-fast` to `false` the other jobs will continue.