### PR TITLE
[skip ci] Add CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '07 10 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
[`CompatHelper`](https://github.com/bcbi/CompatHelper.jl) is a GitHub Action that helps us keeping compatibility versions in `Project.toml` up to date.

I cancelled CI because it's useless to run it for this change.