### PR TITLE
Do not run `MPI.Finalize()`

### DIFF
--- a/src/TDAC.jl
+++ b/src/TDAC.jl
@@ -512,7 +512,10 @@ function tdac(params::tdac_params)
 
     end
 
-    MPI.Finalize()
+    # At this point we should call `MPI.Finalize()`, but this will be
+    # automatically run at the end of the Julia session.  Not having
+    # `MPI.Finalize()` here allows us to call `tdac()` multiple times during the
+    # same session.
 
     return state_true, state_avg
 end


### PR DESCRIPTION
Calling `MPI.Finalize()` is optional, as Julia will automatically calls it on
exit, see
https://juliaparallel.github.io/MPI.jl/v0.14/environment.html#MPI.Finalize and
https://github.com/JuliaParallel/MPI.jl/blob/b16fc92474fa070712d2ff8b1af5c36ecd09cfa6/src/environment.jl#L76.