### PR TITLE
Generate Gaussian random field with `primes=true`

### DIFF
--- a/src/TDAC.jl
+++ b/src/TDAC.jl
@@ -192,7 +192,7 @@ function init_gaussian_random_field_generator(lambda::T,
     dim = 2
 
     cov = CovarianceFunction(dim, Matern(lambda, nu, σ = sigma))
-    grf = GaussianRandomField(cov, CirculantEmbedding(), x, y, minpadding=pad)
+    grf = GaussianRandomField(cov, CirculantEmbedding(), x, y, minpadding=pad, primes=true)
 
 end
 


### PR DESCRIPTION
As shown in https://github.com/Team-RADDISH/TDAC.jl/issues/35#issuecomment-627476870 this should speedup a bit the computation of the FFT.

Maybe we want to make this a parameter?