### PR TITLE
Define a thread-safe RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 GaussianRandomFields = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
## Implementation

This PR defines a thread-safe RNG, as prescribed in [Julia documentation](https://docs.julialang.org/en/v1.4/manual/parallel-computing/#Side-effects-and-mutable-function-arguments-1).  This makes it possible to actually parallelise the computation of the random noise.

## Benchmarks

With the following script:
```julia
using TDAC, FFTW, MPI
using TimerOutputs
TimerOutputs.enable_debug_timings(TDAC)

# Disable FFTW threads
FFTW.set_num_threads(1)

if !MPI.Initialized()
    # Initialise MPI
    MPI.Init()
end

# Define a convenience method to easily replace some parametres
function (p::TDAC.tdac_params)(; kwargs...)
    # Extract parameters of the input instance
    fields = Dict(name => getfield(p, name) for name in fieldnames(typeof(p)))
    for (k, v) in kwargs
        # Replace the fields with the new values
        fields[k] = v
    end
    # Return the new instance
    return TDAC.tdac_params(; fields...)
end

# Get the number or ranks, so that we can set a number of particle as an integer
# multiple of them.
my_size = MPI.Comm_size(MPI.COMM_WORLD)

params = TDAC.tdac_params(; nprt = my_size, nobs = 4, padding = 0, enable_timers = true,
                          verbose = true, n_time_step = 5, nx = 200, ny = 200)

# Warmup
rm("tdac.h5"; force = true)
tdac(params)
# Flush a newline
println()

# Run the command
rm("tdac.h5"; force = true)
tdac(params(; nprt = 32 * my_size, nobs = 64, n_time_step = 20))
# Flush a newline
println()

```
with this PR I get the following results, with 1 thread:
```
 ────────────────────────────────────────────────────────────────────────────────
                                         Time                   Allocations      
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             25.5s / 100%             154MiB / 100%     

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 Particle State Update       20    22.5s  88.3%   1.13s   1.57MiB  1.02%  80.3KiB
 Process Noise               20    1.65s  6.48%  82.6ms    136KiB  0.09%  6.81KiB
 True State Update           20    703ms  2.76%  35.1ms   46.3KiB  0.03%  2.31KiB
 Resample                    20    166ms  0.65%  8.31ms   6.56KiB  0.00%     336B
 Initialization               1    154ms  0.60%   154ms   93.6MiB  60.8%  93.6MiB
 Particle Variance           21    137ms  0.54%  6.54ms   38.5MiB  25.0%  1.83MiB
 Particle Mean               21   69.0ms  0.27%  3.29ms     0.00B  0.00%    0.00B
 IO                          24   48.7ms  0.19%  2.03ms   19.8MiB  12.9%   846KiB
 State Copy                  20   39.2ms  0.15%  1.96ms      640B  0.00%    32.0B
 Observations                40   2.68ms  0.01%  67.0μs    170KiB  0.11%  4.25KiB
 Weights                     20    547μs  0.00%  27.3μs   60.0KiB  0.04%  3.00KiB
 MPI Scatter                 20    226μs  0.00%  11.3μs   3.13KiB  0.00%     160B
 MPI Gather                  40    220μs  0.00%  5.50μs   5.31KiB  0.00%     136B
 ────────────────────────────────────────────────────────────────────────────────
```
2 threads
```
 ────────────────────────────────────────────────────────────────────────────────
                                         Time                   Allocations      
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             13.6s / 100%             155MiB / 100%     

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 Particle State Update       20    11.5s  84.2%   573ms   1.58MiB  1.02%  81.1KiB
 Process Noise               20    826ms  6.07%  41.3ms    150KiB  0.10%  7.52KiB
 True State Update           20    692ms  5.08%  34.6ms   46.3KiB  0.03%  2.31KiB
 Particle Variance           21    172ms  1.26%  8.18ms   38.5MiB  24.9%  1.83MiB
 Resample                    20    170ms  1.25%  8.49ms   6.56KiB  0.00%     336B
 Initialization               1    125ms  0.92%   125ms   94.3MiB  61.0%  94.3MiB
 Particle Mean               21   68.9ms  0.51%  3.28ms     0.00B  0.00%    0.00B
 IO                          24   48.0ms  0.35%  2.00ms   19.8MiB  12.8%   846KiB
 State Copy                  20   44.6ms  0.33%  2.23ms      640B  0.00%    32.0B
 Observations                40   2.53ms  0.02%  63.2μs    170KiB  0.11%  4.25KiB
 Weights                     20    553μs  0.00%  27.6μs   60.0KiB  0.04%  3.00KiB
 MPI Gather                  40    211μs  0.00%  5.27μs   5.31KiB  0.00%     136B
 MPI Scatter                 20    204μs  0.00%  10.2μs   3.13KiB  0.00%     160B
 ────────────────────────────────────────────────────────────────────────────────
```
and 4 threads:
```
 ────────────────────────────────────────────────────────────────────────────────
                                         Time                   Allocations      
                                 ──────────────────────   ───────────────────────
        Tot / % measured:             8.27s / 100%             156MiB / 100%     

 Section                 ncalls     time   %tot     avg     alloc   %tot      avg
 ────────────────────────────────────────────────────────────────────────────────
 Particle State Update       20    6.46s  78.0%   323ms   1.61MiB  1.03%  82.5KiB
 True State Update           20    686ms  8.29%  34.3ms   46.3KiB  0.03%  2.31KiB
 Process Noise               20    464ms  5.61%  23.2ms    179KiB  0.11%  8.96KiB
 Resample                    20    181ms  2.19%  9.04ms   6.56KiB  0.00%     336B
 Particle Variance           21    151ms  1.82%  7.17ms   38.5MiB  24.7%  1.83MiB
 Initialization               1    144ms  1.74%   144ms   95.5MiB  61.3%  95.5MiB
 Particle Mean               21   80.1ms  0.97%  3.81ms     0.00B  0.00%    0.00B
 State Copy                  20   65.3ms  0.79%  3.27ms      640B  0.00%    32.0B
 IO                          24   43.6ms  0.53%  1.82ms   19.8MiB  12.7%   846KiB
 Observations                40   2.59ms  0.03%  64.7μs    170KiB  0.11%  4.25KiB
 Weights                     20    605μs  0.01%  30.3μs   60.0KiB  0.04%  3.00KiB
 MPI Gather                  40    247μs  0.00%  6.17μs   5.31KiB  0.00%     136B
 MPI Scatter                 20    209μs  0.00%  10.5μs   3.13KiB  0.00%     160B
 ────────────────────────────────────────────────────────────────────────────────
```

The scaling of "Process Noise" with 2 threads is perfect, less so with 4 threads, the scaling is closer to 3 than 4, but still not too bad.