### PR TITLE
Use in-place version of `var`

### DIFF
--- a/src/TDAC.jl
+++ b/src/TDAC.jl
@@ -622,7 +622,7 @@ function tdac(params::tdac_params)
     # Write initial state + metadata
     if(params.verbose && my_rank == params.master_rank)
         @timeit_debug timer "Particle Mean" Statistics.mean!(states.avg, states.particles)
-        @timeit_debug timer "Particle Variance" states.var .= dropdims(Statistics.var(states.particles; dims=4), dims=4)
+        @timeit_debug timer "Particle Variance" Statistics.varm!(states.var, states.particles, states.avg)
 
         @timeit_debug timer "IO" write_grid(params)
         @timeit_debug timer "IO" write_params(params)


### PR DESCRIPTION
Currently we're doing this to compute the variance of the components:
```julia
julia> using Statistics

julia> A = randn(200, 200, 3, 3);

julia> dropdims(var(A; dims = 4, mean = m); dims = 4);
```
With this PR I propose to do this:
```julia
julia> m = dropdims(mean(A; dims = 4); dims = 4);

julia> R = zeros(200, 200, 3);

julia> Statistics.varm!(R, A, m);
```
The two expressions give exactly -- not approximately -- the same result:
```julia
julia> dropdims(var(A; dims = 4); dims = 4) == R
true
```
but the in-place `varm!` is totally allocation-free and a bit faster:
```julia
julia> @benchmark dropdims(var($A; dims = 4); dims = 4)
BenchmarkTools.Trial: 
  memory estimate:  1.83 MiB
  allocs estimate:  38
  --------------
  minimum time:     1.216 ms (0.00% GC)
  median time:      1.235 ms (0.00% GC)
  mean time:        1.274 ms (1.04% GC)
  maximum time:     2.265 ms (12.49% GC)
  --------------
  samples:          3923
  evals/sample:     1

julia> @benchmark Statistics.varm!($R, $A, $m)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     351.829 μs (0.00% GC)
  median time:      368.865 μs (0.00% GC)
  mean time:        371.955 μs (0.00% GC)
  maximum time:     623.331 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```