### PR TITLE
Use allocation-free `var` everywhere

### DIFF
--- a/src/TDAC.jl
+++ b/src/TDAC.jl
@@ -715,7 +715,7 @@ function tdac(params::tdac_params)
 
             # Calculate statistical quantities
             @timeit_debug timer "Particle Mean" Statistics.mean!(states.avg, states.particles)
-            @timeit_debug timer "Particle Variance" states.var .= dropdims(Statistics.var(states.particles; dims=4), dims=4)
+            @timeit_debug timer "Particle Variance" Statistics.varm!(states.var, states.particles, states.avg)
 
             # Write output
             if params.verbose


### PR DESCRIPTION
In #98 I forgot to use `varm!` in all places, in that PR it was used only at init-time :grimacing: 