### PR TITLE
Refactor llw2d.initheight

### DIFF
--- a/test/model/model.jl
+++ b/test/model/model.jl
@@ -80,6 +80,8 @@ Base.@kwdef struct ModelParameters{T<:AbstractFloat}
 
     source_size::T = 3.0e4
     bathymetry_setup::T = 3.0e4
+    peak_height = 1.0
+    peak_position = [floor(Int, nx / 4) * dx, floor(Int, ny / 4) * dy]
 
     lambda::T = 1.0e4
     nu::T = 2.5
@@ -346,7 +348,8 @@ function set_initial_state!(states::StateVectors, model_matrices::LLW2d.Matrices
                             params::ModelParameters) where T
 
     # Set true initial state
-    LLW2d.initheight!(@view(states.truth[:, :, 1]), model_matrices, params.dx, params.dy, params.source_size)
+    LLW2d.initheight!(@view(states.truth[:, :, 1]), model_matrices, params.dx, params.dy,
+                      params.source_size, params.peak_height, params.peak_position)
 
     # Create generator for the initial random field
     x,y = get_axes(params)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,14 +27,17 @@ using .Model: ModelParameters
     @test jst == [75, 85, 95, 75, 85, 95, 75, 85, 95]
 
     ### initheight!
-    eta = ones(2, 2)
-    ocean_depth  = ones(2, 2)
-    LLW2d.initheight!(eta, ocean_depth, dx, dy, 3e4)
+    nx = 2
+    ny = 2
+    eta = ones(nx, ny)
+    ocean_depth  = ones(nx, ny)
+    peak_position = [floor(Int, nx/4) * dx, floor(Int, ny/4) * dy]
+    LLW2d.initheight!(eta, ocean_depth, dx, dy, 3e4, 1.0, peak_position)
     @test eta ≈ [0.978266982572228  0.9463188389826958;
                  0.9463188389826958 0.9154140546161575]
     eta = ones(2, 2)
     ocean_depth  = zeros(2, 2)
-    LLW2d.initheight!(eta, ocean_depth, dx, dy, 3e4)
+    LLW2d.initheight!(eta, ocean_depth, dx, dy, 3e4, 1.0, peak_position)
     @test eta ≈ zeros(2, 2)
 
     # timestep.  TODO: add real tests.  So far we're just making sure code won't
@@ -138,8 +141,9 @@ end
 
     # Initialise and update a tsunami on a small grid
     s = 4e3
-    eta = reshape(@view(x[1:nx*ny]), nx, ny)
-    LLW2d.initheight!(eta, model_matrices, dx, dy, s)
+    peak_position = [floor(Int, nx/4) * dx, floor(Int, ny/4) * dy]
+    eta = @view(x[:,:,1])
+    LLW2d.initheight!(eta, model_matrices, dx, dy, s, 1.0, peak_position)
     @test eta[2,2] ≈ 1.0
     @test sum(eta) ≈ 4.0
     Model.tsunami_update!(dxeta, dyeta, x, nt, dx, dy, dt, model_matrices)


### PR DESCRIPTION
closes #134 

* Added parameters for peak position and peak height that were previously hard-coded
* Created a helper function `get_initial_height` that can be broadcast over the grid. No need for loops.

Master:
```
@btime Model.LLW2d.initheight!(h, matrices.ocean_depth, params.dx, params.dy, params.source_size);
  4.016 ms (120006 allocations: 10.99 MiB)
```

This PR
```
@btime Model.LLW2d.initheight!(h, matrices.ocean_depth, params.dx, params.dy, params.source_size, params.peak_height, params.peak_position);
  237.715 μs (11 allocations: 9.61 KiB)
```