### PR TITLE
Split get_grid_size into three functions 

### DIFF
--- a/src/OptimalFilter.jl
+++ b/src/OptimalFilter.jl
@@ -36,6 +36,15 @@ struct OnlineMatrices{T<:AbstractVector, S<:AbstractArray, U<:AbstractArray}
 
 end
 
+struct Grid{T}
+    nx::Int
+    ny::Int
+    dx::T
+    dy::T
+    x_length::T
+    y_length::T
+end
+
 # Covariance function r(x,y), equation 1 in Dietrich and Newsam 96
 function covariance(x::T, y::T, noise_params::NamedTuple) where T
 
@@ -44,7 +53,7 @@ function covariance(x::T, y::T, noise_params::NamedTuple) where T
 end
 
 # Extended covariance function /bar r(x,y), equation 8 of Dietrich and Newsam 96
-function extended_covariance(x::T, y::T, grid, noise_params::NamedTuple) where T
+function extended_covariance(x::T, y::T, grid::Grid, noise_params::NamedTuple) where T
 
     if 0 <= x <= grid.x_length
         x_ext = x
@@ -67,7 +76,7 @@ function extended_covariance(x::T, y::T, grid, noise_params::NamedTuple) where T
 end
 
 # Covariance between observations and the extended grid /bar R_21, from equation 11 in Dietrich & Newsam 96
-function covariance_stations_extended_grid!(cov::AbstractMatrix{T}, grid, grid_ext, stations::NamedTuple, noise_params::NamedTuple) where T
+function covariance_stations_extended_grid!(cov::AbstractMatrix{T}, grid::Grid, grid_ext::Grid, stations::NamedTuple, noise_params::NamedTuple) where T
 
     xid = 1:grid_ext.nx
     yid = 1:grid_ext.ny
@@ -85,7 +94,7 @@ function covariance_stations_extended_grid!(cov::AbstractMatrix{T}, grid, grid_e
 end
 
 # Covariance between stations and the original grid R_21, from equations 3-4 in Dietrich & Newsam 96
-function covariance_grid_stations!(cov::AbstractMatrix{T}, grid, stations::NamedTuple, noise_params::NamedTuple) where T
+function covariance_grid_stations!(cov::AbstractMatrix{T}, grid::Grid, stations::NamedTuple, noise_params::NamedTuple) where T
 
     xid = 1:grid.nx
     yid = 1:grid.ny
@@ -104,7 +113,7 @@ end
 
 # Covariance between observations R_22, from equationd 3-4 in in Dietrich & Newsam 96
 # TODO: Ask Alex why we add sigma^2 on the diagonal
-function covariance_stations!(cov::AbstractMatrix{T}, grid, stations::NamedTuple, noise_params::NamedTuple, std::T) where T
+function covariance_stations!(cov::AbstractMatrix{T}, grid::Grid, stations::NamedTuple, noise_params::NamedTuple, std::T) where T
 
     cov .= covariance.(abs.(stations.ist .- stations.ist') .* grid.dx,
                        abs.(stations.jst' .- stations.jst) .* grid.dy,
@@ -114,7 +123,7 @@ end
 
 # First column vector rho_bar of covariance matrix among pairs of points of the extended grid R11_bar,
 # from Dietrich & Newsam 96 described in text between equations 11 and 12
-function first_column_covariance_grid!(rho::AbstractVector{T}, grid, grid_ext, noise_params::NamedTuple) where T
+function first_column_covariance_grid!(rho::AbstractVector{T}, grid::Grid, grid_ext::Grid, noise_params::NamedTuple) where T
 
     xid = 1:grid_ext.nx
     yid = 1:grid_ext.ny
@@ -170,7 +179,7 @@ end
 
 # Decomposition of R11, equation 12 of Deitrich and Newsam
 function WΛWH_decomposition!(transformed_array::AbstractMatrix{T}, array::AbstractMatrix{T},
-                             offline_matrices::OfflineMatrices, grid, grid_ext) where T
+                             offline_matrices::OfflineMatrices, grid::Grid, grid_ext::Grid) where T
 
     @assert size(array) == (grid.nx, grid.ny)
 
@@ -202,7 +211,7 @@ function get_values_at_stations(field::AbstractMatrix{T}, stations) where T
 end
 
 # Allocate and compute matrices that do not depend on time-dependent variables (height and observations).
-function init_offline_matrices(grid, grid_ext, stations::NamedTuple, noise_params::NamedTuple, obs_noise_std::T, F::Type) where T
+function init_offline_matrices(grid::Grid, grid_ext::Grid, stations::NamedTuple, noise_params::NamedTuple, obs_noise_std::T, F::Type) where T
 
     n1 = grid.nx * grid.ny # number of elements in original grid
     n1_bar = grid_ext.nx * grid_ext.ny # number of elements in extended grid
@@ -255,7 +264,7 @@ function init_offline_matrices(grid, grid_ext, stations::NamedTuple, noise_param
 end
 
 # Allocate memory for matrices that will be updated during the time stepping loop.
-function init_online_matrices(grid, grid_ext, stations::NamedTuple, filter_params, T::Type)
+function init_online_matrices(grid::Grid, grid_ext::Grid, stations::NamedTuple, filter_params, T::Type)
 
     n1 = grid.nx * grid.ny # number of elements in original grid
     n1_bar = grid_ext.nx * grid_ext.ny # number of elements in extended grid
@@ -278,7 +287,7 @@ end
 # Calculate the mean for the optimal proposal of the height
 function calculate_mean_height!(mean::AbstractArray{T,3}, height::AbstractArray{T,3},
                                 offline_matrices::OfflineMatrices, observations::AbstractVector{T},
-                                stations::NamedTuple, grid, grid_ext,
+                                stations::NamedTuple, grid::Grid, grid_ext::Grid,
                                 filter_params, obs_noise_std::T) where T
 
     # The arguments for the WΛWH decompositions are matrices that only have nonzero values
@@ -320,8 +329,8 @@ end
 
 function sample_height_proposal!(height::AbstractArray{T,3},
                                  offline_matrices::OfflineMatrices, online_matrices::OnlineMatrices,
-                                 observations::AbstractVector{T}, stations::NamedTuple, grid,
-                                 grid_ext, filter_params, rng::Random.AbstractRNG, obs_noise_std::T) where T
+                                 observations::AbstractVector{T}, stations::NamedTuple, grid::Grid,
+                                 grid_ext::Grid, filter_params, rng::Random.AbstractRNG, obs_noise_std::T) where T
 
     @assert iseven(filter_params.nprt) "Number of particles must be even"
 

--- a/src/ParticleDA.jl
+++ b/src/ParticleDA.jl
@@ -14,13 +14,13 @@ using .Default_params
 # Functions to extend in the model
 
 """
-    ParticleDA.get_grid_dims(model_data) -> NTuple{N, Int} where N
+    ParticleDA.get_grid_size(model_data) -> NTuple{N, Int} where N
 
 Return a tuple with the dimensions (number of nodes) of the grid.
 """
 function get_grid_size end
 """
-    ParticleDA.get_grid_size(model_data) -> NTuple{N, float} where N
+    ParticleDA.get_grid_domain_size(model_data) -> NTuple{N, float} where N
 
 Return a tuple with the dimensions (metres) of the grid domain.
 """
@@ -349,15 +349,6 @@ function init_filter(filter_params::FilterParameters, model_data, nprt_per_rank:
     copy_buffer = Array{T,4}(undef, size..., n_state_var, nprt_per_rank)
 
     return (;weights, resampling_indices, statistics, avg_arr, var_arr, copy_buffer)
-end
-
-struct Grid{T}
-    nx::Int
-    ny::Int
-    dx::T
-    dy::T
-    x_length::T
-    y_length::T
 end
 
 # Initialize arrays used by the filter

--- a/src/ParticleDA.jl
+++ b/src/ParticleDA.jl
@@ -371,7 +371,7 @@ function init_filter(filter_params::FilterParameters, model_data, nprt_per_rank:
     csize = get_grid_cell_size(model_data)
 
     grid = Grid(dims...,csize...,size...)
-    grid_ext = Grid(((grid.nx-1)*2, (grid.ny-1)*2, grid.dx, grid.dy, (grid.x_length-grid.dx)*2, (grid.y_length-grid.dy)*2))
+    grid_ext = Grid((grid.nx-1)*2, (grid.ny-1)*2, grid.dx, grid.dy, (grid.x_length-grid.dx)*2, (grid.y_length-grid.dy)*2)
 
     model_noise_params = get_model_noise_params(model_data)
     obs_noise_std = get_obs_noise_std(model_data)

--- a/src/ParticleDA.jl
+++ b/src/ParticleDA.jl
@@ -18,13 +18,13 @@ using .Default_params
 
 Return a tuple with the dimensions (number of nodes) of the grid.
 """
-function get_grid_dims end
+function get_grid_size end
 """
     ParticleDA.get_grid_size(model_data) -> NTuple{N, float} where N
 
-Return a tuple with the dimensions (metres) of the grid.
+Return a tuple with the dimensions (metres) of the grid domain.
 """
-function get_grid_size end
+function get_grid_domain_size end
 """
     ParticleDA.get_grid_cell_size(model_data) -> NTuple{N, float} where N
 
@@ -338,15 +338,15 @@ function init_filter(filter_params::FilterParameters, model_data, nprt_per_rank:
 
     resampling_indices = Vector{Int}(undef, filter_params.nprt)
 
-    dims = get_grid_dims(model_data)
+    size = get_grid_size(model_data)
     n_state_var = get_n_state_var(model_data)
 
-    statistics = Array{SummaryStat{T}, 3}(undef, dims..., n_state_var)
-    avg_arr = Array{T,3}(undef, dims..., n_state_var)
-    var_arr = Array{T,3}(undef, dims..., n_state_var)
+    statistics = Array{SummaryStat{T}, 3}(undef, size..., n_state_var)
+    avg_arr = Array{T,3}(undef, size..., n_state_var)
+    var_arr = Array{T,3}(undef, size..., n_state_var)
 
     # Memory buffer used during copy of the states
-    copy_buffer = Array{T,4}(undef, dims..., n_state_var, nprt_per_rank)
+    copy_buffer = Array{T,4}(undef, size..., n_state_var, nprt_per_rank)
 
     return (;weights, resampling_indices, statistics, avg_arr, var_arr, copy_buffer)
 end
@@ -366,11 +366,11 @@ function init_filter(filter_params::FilterParameters, model_data, nprt_per_rank:
     filter_data = init_filter(filter_params, model_data, nprt_per_rank, T, BootstrapFilter())
 
     stations = get_stations(model_data)
-    dims = get_grid_dims(model_data)
     size = get_grid_size(model_data)
-    csize = get_grid_cell_size(model_data)
+    domain_size = get_grid_domain_size(model_data)
+    cell_size = get_grid_cell_size(model_data)
 
-    grid = Grid(dims...,csize...,size...)
+    grid = Grid(size...,cell_size...,domain_size...)
     grid_ext = Grid((grid.nx-1)*2, (grid.ny-1)*2, grid.dx, grid.dy, (grid.x_length-grid.dx)*2, (grid.y_length-grid.dy)*2)
 
     model_noise_params = get_model_noise_params(model_data)

--- a/test/model/model.jl
+++ b/test/model/model.jl
@@ -426,12 +426,9 @@ function ParticleDA.set_particles!(d::ModelData, particles::AbstractArray{T}) wh
     d.states.particles .= particles
 
 end
-ParticleDA.get_grid_size(d::ModelData) = (nx = d.model_params.nx,
-                                          ny = d.model_params.ny,
-                                          dx = d.model_params.dx,
-                                          dy = d.model_params.dy,
-                                          x_length = d.model_params.x_length,
-                                          y_length = d.model_params.y_length)
+ParticleDA.get_grid_dims(d::ModelData) = d.model_params.nx,d.model_params.ny
+ParticleDA.get_grid_size(d::ModelData) = d.model_params.x_length,d.model_params.y_length
+ParticleDA.get_grid_cell_size(d::ModelData) = d.model_params.dx,d.model_params.dy
 ParticleDA.get_n_state_var(d::ModelData) = d.model_params.n_state_var
 
 function init(model_params_dict::Dict, nprt_per_rank::Int, my_rank::Integer, _rng::Union{Random.AbstractRNG,Nothing}=nothing)

--- a/test/model/model.jl
+++ b/test/model/model.jl
@@ -426,8 +426,8 @@ function ParticleDA.set_particles!(d::ModelData, particles::AbstractArray{T}) wh
     d.states.particles .= particles
 
 end
-ParticleDA.get_grid_dims(d::ModelData) = d.model_params.nx,d.model_params.ny
-ParticleDA.get_grid_size(d::ModelData) = d.model_params.x_length,d.model_params.y_length
+ParticleDA.get_grid_size(d::ModelData) = d.model_params.nx,d.model_params.ny
+ParticleDA.get_grid_domain_size(d::ModelData) = d.model_params.x_length,d.model_params.y_length
 ParticleDA.get_grid_cell_size(d::ModelData) = d.model_params.dx,d.model_params.dy
 ParticleDA.get_n_state_var(d::ModelData) = d.model_params.n_state_var
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -265,18 +265,18 @@ end
     # Use default parameters
     model_params = ModelParameters()
     filter_params = FilterParameters()
-    grid = (nx = model_params.nx,
-            ny = model_params.ny,
-            dx = model_params.dx,
-            dy = model_params.dy,
-            x_length = model_params.x_length,
-            y_length = model_params.y_length)
-    grid_ext = NamedTuple{keys(grid)}(((grid.nx-1)*2,
-                                       (grid.ny-1)*2,
-                                       grid.dx,
-                                       grid.dy,
-                                       (grid.x_length-grid.dx)*2,
-                                       (grid.y_length-grid.dy)*2))
+    grid = ParticleDA.Grid(model_params.nx,
+                           model_params.ny,
+                           model_params.dx,
+                           model_params.dy,
+                           model_params.x_length,
+                           model_params.y_length)
+    grid_ext = ParticleDA.Grid((grid.nx-1)*2,
+                               (grid.ny-1)*2,
+                               grid.dx,
+                               grid.dy,
+                               (grid.x_length-grid.dx)*2,
+                               (grid.y_length-grid.dy)*2)
     noise_params = (sigma = model_params.sigma, lambda = model_params.lambda, nu = model_params.nu)
     
     # Set station coordinates
@@ -331,18 +331,19 @@ end
     filter_params = ParticleDA.get_params(FilterParameters, params_dict["filter"])
     model_params = ParticleDA.get_params(ModelParameters, params_dict["model"]["llw2d"])
 
-    grid = (nx = model_params.nx,
-            ny = model_params.ny,
-            dx = model_params.dx,
-            dy = model_params.dy,
-            x_length = model_params.x_length,
-            y_length = model_params.y_length)
-    grid_ext = NamedTuple{keys(grid)}(((grid.nx-1)*2,
-                                       (grid.ny-1)*2,
-                                       grid.dx,
-                                       grid.dy,
-                                       (grid.x_length-grid.dx)*2,
-                                       (grid.y_length-grid.dy)*2))
+    grid = ParticleDA.Grid(model_params.nx,
+                           model_params.ny,
+                           model_params.dx,
+                           model_params.dy,
+                           model_params.x_length,
+                           model_params.y_length)
+    grid_ext = ParticleDA.Grid((grid.nx-1)*2,
+                               (grid.ny-1)*2,
+                               grid.dx,
+                               grid.dy,
+                               (grid.x_length-grid.dx)*2,
+                               (grid.y_length-grid.dy)*2)
+
     noise_params = (sigma = model_params.sigma, lambda = model_params.lambda, nu = model_params.nu)
 
     stations = (nst = model_params.nobs, ist = st.st_ij[:,1].+1, jst = st.st_ij[:,2].+1)


### PR DESCRIPTION
Each function returns a NTuple so that they can be used for higher dimensional grids. This will address comments in #133 