### PR TITLE
Use correct number of particles in Optimal Filter and add MPI test

### DIFF
--- a/test/mpi.jl
+++ b/test/mpi.jl
@@ -14,7 +14,6 @@ params = Dict(
     "filter" => Dict(
         "nprt" => my_size,
         "enable_timers" => true,
-        "verbose" => true,
         "n_time_step" => 5,
     ),
     "model" => Dict(
@@ -38,5 +37,11 @@ rm("particle_da.h5"; force = true)
 params["filter"]["nprt"] = 2 * my_size
 params["model"]["llw2d"]["nobs"] = 36
 run_particle_filter(Model.init, params, BootstrapFilter())
+# Flush a newline
+println()
+
+# Run the command
+rm("particle_da.h5"; force = true)
+run_particle_filter(Model.init, params, OptimalFilter())
 # Flush a newline
 println()

--- a/test/mpi.jl
+++ b/test/mpi.jl
@@ -14,8 +14,9 @@ params = Dict(
     "filter" => Dict(
         "nprt" => my_size,
         "enable_timers" => true,
-        "verbose"=> true,
+        "verbose"=> false,
         "n_time_step" => 5,
+        "output_filename" => "warmup.h5",
     ),
     "model" => Dict(
         "llw2d" => Dict(
@@ -28,13 +29,13 @@ params = Dict(
 )
 
 # Warmup
-rm("particle_da.h5"; force = true)
 run_particle_filter(Model.init, params, BootstrapFilter())
 # Flush a newline
 println()
 
 # Run the command
-rm("particle_da.h5"; force = true)
+params["filter"]["output_filename"] = "bootstrap_filter.h5"
+params["filter"]["verbose"] = true
 params["filter"]["nprt"] = 2 * my_size
 params["model"]["llw2d"]["nobs"] = 36
 run_particle_filter(Model.init, params, BootstrapFilter())
@@ -42,7 +43,7 @@ run_particle_filter(Model.init, params, BootstrapFilter())
 println()
 
 # Run the command
-rm("particle_da.h5"; force = true)
+params["filter"]["output_filename"] = "optimal_filter.h5"
 run_particle_filter(Model.init, params, OptimalFilter())
 # Flush a newline
 println()

--- a/test/mpi.jl
+++ b/test/mpi.jl
@@ -14,6 +14,7 @@ params = Dict(
     "filter" => Dict(
         "nprt" => my_size,
         "enable_timers" => true,
+        "verbose"=> true,
         "n_time_step" => 5,
     ),
     "model" => Dict(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -327,13 +327,13 @@ end
     tmp_array = Matrix{ComplexF64}(undef, grid_ext.nx, grid_ext.ny)
     fft_plan, fft_plan! = FFTW.plan_fft(tmp_array), FFTW.plan_fft!(tmp_array)
     mat_off = ParticleDA.init_offline_matrices(grid, grid_ext, stations, noise_params, model_params.obs_noise_std, fft_plan, fft_plan!, Float64)
-    mat_on = ParticleDA.init_online_matrices(grid, grid_ext, stations, filter_params, Float64)
+    mat_on = ParticleDA.init_online_matrices(grid, grid_ext, stations, filter_params.nprt, Float64)
     @test minimum(mat_off.Lambda) > 0.0
-    ParticleDA.calculate_mean_height!(mat_on.mean, height, mat_off, obs, stations, grid, grid_ext, fft_plan, fft_plan!, filter_params, model_params.obs_noise_std)
+    ParticleDA.calculate_mean_height!(mat_on.mean, height, mat_off, obs, stations, grid, grid_ext, fft_plan, fft_plan!, filter_params.nprt, model_params.obs_noise_std)
     @test all(isfinite, mat_on.mean)
 
     rng = Random.MersenneTwister(seed)
-    ParticleDA.sample_height_proposal!(height, mat_off, mat_on, obs, stations, grid, grid_ext, fft_plan, fft_plan!, filter_params, rng, model_params.obs_noise_std)
+    ParticleDA.sample_height_proposal!(height, mat_off, mat_on, obs, stations, grid, grid_ext, fft_plan, fft_plan!, filter_params.nprt, rng, model_params.obs_noise_std)
     @test all(isfinite, mat_on.samples)
 
 end
@@ -383,9 +383,9 @@ end
     tmp_array = Matrix{ComplexF64}(undef, grid_ext.nx, grid_ext.ny)
     fft_plan, fft_plan! = FFTW.plan_fft(tmp_array), FFTW.plan_fft!(tmp_array)
     mat_off = ParticleDA.init_offline_matrices(grid, grid_ext, stations, noise_params, model_params.obs_noise_std, fft_plan, fft_plan!, Float64)
-    mat_on = ParticleDA.init_online_matrices(grid, grid_ext, stations, filter_params, Float64)
+    mat_on = ParticleDA.init_online_matrices(grid, grid_ext, stations, filter_params.nprt, Float64)
 
-    ParticleDA.sample_height_proposal!(height, mat_off, mat_on, obs, stations, grid, grid_ext, fft_plan, fft_plan!, filter_params, rng, model_params.obs_noise_std)
+    ParticleDA.sample_height_proposal!(height, mat_off, mat_on, obs, stations, grid, grid_ext, fft_plan, fft_plan!, filter_params.nprt, rng, model_params.obs_noise_std)
 
     Yobs_t = copy(obs)
     FH_t = copy(reshape(permutedims(height, [3 1 2]), filter_params.nprt, (model_params.nx)*(model_params.ny)))


### PR DESCRIPTION
Optimal Filter does not do any global operations over particles, so we can simply substitute `nprt_per_rank` for `filter_params.nprt`. This has an added benefit of not having to pass `filter_params` at all to most functions, since `nprt` was the only field being used.

Optimal Filter is now included in the tests in `mpi.jl`, so we should at least catch MPI errors a bit sooner.

Also removed verbose output from the MPI test, didn't see any reason to have it. Unless someone disagrees? The MPI test also enables timers, do we want to keep that?

Closes #209 