### PR TITLE
Propagate number of threads when running MPI tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,7 +267,7 @@ end
     mpiexec() do mpiexec
         mktempdir() do dir
             cd(dir) do
-                @test success(run(ignorestatus(`$(mpiexec) -n 3 $(julia) $(flags) $(script)`)))
+                @test success(run(ignorestatus(`$(mpiexec) -n 3 $(julia) -t$(Base.Threads.nthreads()) $(flags) $(script)`)))
             end
         end
     end


### PR DESCRIPTION
While looking at new failures in #210 I realised we always use a single in MPI
tests because we don't forward the number of threads to the `julia` subprocess
we spawn.  I think it'd be good to run the tests with multiple MPI ranks +
multiple threads.