### PR TITLE
Move threads flags to `flags` variable in MPI tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,12 +262,12 @@ end
 
 @testset "MPI -- $(file)" for file in ("mpi.jl", "copy_states.jl", "mean_and_var.jl")
     julia = joinpath(Sys.BINDIR, Base.julia_exename())
-    flags = ["--startup-file=no", "-q"]
+    flags = ["--startup-file=no", "-q", "-t$(Base.Threads.nthreads())"]
     script = joinpath(@__DIR__, file)
     mpiexec() do mpiexec
         mktempdir() do dir
             cd(dir) do
-                @test success(run(ignorestatus(`$(mpiexec) -n 3 $(julia) -t$(Base.Threads.nthreads()) $(flags) $(script)`)))
+                @test success(run(ignorestatus(`$(mpiexec) -n 3 $(julia) $(flags) $(script)`)))
             end
         end
     end


### PR DESCRIPTION
Ref: https://github.com/Team-RADDISH/ParticleDA.jl/pull/211#issuecomment-1015602359