### PR TITLE
Run MPI tests with `Base.julia_cmd` instead of `Base.julia_exename`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - x64
         threads: [1, 2]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
@@ -35,5 +35,8 @@ jobs:
           cache-name: "tests"
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
-      - uses: julia-actions/julia-uploadcodecov@v0.1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info
         continue-on-error: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/cache@v1
         with:
           cache-name: "docs"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -820,7 +820,7 @@ end
 @testset "MPI test -- $(file)" for file in (
     "mpi_filtering.jl", "mpi_copy_states.jl", "mpi_summary_statistics.jl"
 )
-    julia = joinpath(Sys.BINDIR, Base.julia_exename())
+    julia = Base.julia_cmd()
     flags = ["--startup-file=no", "-q", "-t$(Base.Threads.nthreads())"]
     script = joinpath(@__DIR__, file)
     mpiexec() do mpiexec


### PR DESCRIPTION
This ensures the same optimisation flags are passed to the processes we spawn, which affect cache invalidation.

I noticed tests with Julia nightly in #233 were hanging.  I believe the problem is the same as https://github.com/JuliaParallel/MPI.jl/pull/706, which took me a while to debug, but at least I did it once and now I know what's the culprit.