### PR TITLE
Fix Lorenz 63 model filtering bug

### DIFF
--- a/test/models/lorenz63.jl
+++ b/test/models/lorenz63.jl
@@ -2,7 +2,6 @@ module Lorenz63
 
 using Base.Threads
 using Distributions
-using FillArrays
 using HDF5
 using Random
 using PDMats
@@ -57,7 +56,7 @@ function init(
             Tsit5();
             save_everystep=false
         ) 
-        for u in eachcol(Matrix{S}(undef, 3, n_tasks))
+        for u in eachcol(zeros(S, 3, n_tasks))
     ]
     state_dimension = 3
     observation_dimension = length(parameters.observed_indices)
@@ -67,9 +66,9 @@ function init(
         (
             MvNormal(m, isa(s, Vector) ? PDiagMat(s.^2) : ScalMat(length(m), s.^2))
             for (m, s) in (
-                (Ones{S}(state_dimension), parameters.initial_state_std), 
-                (Zeros{S}(state_dimension), parameters.state_noise_std), 
-                (Zeros{T}(observation_dimension), parameters.observation_noise_std), 
+                (ones(S, state_dimension), parameters.initial_state_std), 
+                (zeros(S, state_dimension), parameters.state_noise_std), 
+                (zeros(T, observation_dimension), parameters.observation_noise_std), 
             )
         )...
     )


### PR DESCRIPTION
Something seems to have changed in recent `FillArrays` / `Distributions` versions in the behaviour when setting mean and (co)variance parameters for `MvNormal` using `FillArrays` lazy array types `Ones` and `Zeros` rather than explicit array initializers `ones` and `zeros`, which appears to be leading to unintended interactions between particle updates when filtering. This PR switches to using the explicit array initializers and also initializes integrator state specifically to zero rather than `undef` to avoid numerical warnings from `OrdinaryDiffEq`.