### PR TITLE
Ignore result of runs with nightly builds in CI job status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       JULIA_NUM_THREADS: ${{ matrix.threads }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This replicates the approach in https://github.com/JuliaTime/TimeZones.jl/pull/418 also discussed in https://github.com/actions/runner/issues/2347 and https://github.com/orgs/community/discussions/15452, for trying to have failures of the CI runs on Julia nightly version not cause the overall workflow status to be a failure. I _think_ that this would mean the workflow status (and so status badge, tick / cross indicator in commit history) would remain green on nightly failures while still showing the failures in the individual job statuses, though I'm not totally sure on this so partly opening up this PR to test. Ideally we would have some alternative visual indicator for the overall workflow status to highlight some optional jobs failing, but given the above linked discussions suggest this has been a long requested GitHub Actions feature with no movement as of yet, I would say having the workflow statuses indicating passing even when nightly builds are failing is overall preferable to having them always showing as failing in this case.