### PR TITLE
Solve some deprecation warnings

### DIFF
--- a/test/models/llw2d.jl
+++ b/test/models/llw2d.jl
@@ -360,7 +360,6 @@ end
 function ParticleDA.get_covariance_observation_noise(model::LLW2dModel)
     observation_dimension = ParticleDA.get_observation_dimension(model)
     return PDiagMat(
-        observation_dimension,
         [
             ParticleDA.get_covariance_observation_noise(model, i, i) 
             for i in 1:observation_dimension

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -937,7 +937,5 @@ end
     julia = Base.julia_cmd()
     flags = ["--startup-file=no", "-q", "-t$(Base.Threads.nthreads())"]
     script = joinpath(@__DIR__, file)
-    mpiexec() do mpiexec
-        @test success(run(ignorestatus(`$(mpiexec) -n 3 $(julia) $(flags) $(script)`)))
-    end
+    @test success(run(ignorestatus(`$(mpiexec()) -n 3 $(julia) $(flags) $(script)`)))
 end


### PR DESCRIPTION
```
┌ Warning: mpiexec() is deprecated, use the non-do-block form
│   caller = ip:0x0
└ @ Core :-1
┌ Warning: `PDiagMat(dim::Int, diag::AbstractVector{<:Real})` is deprecated, use `PDiagMat(diag)` instead.
│   caller = ip:0x0
└ @ Core :-1
```